### PR TITLE
Feature/14 UI refresh hints

### DIFF
--- a/DontGoHomeStraight/Domain/Entities/Genre.swift
+++ b/DontGoHomeStraight/Domain/Entities/Genre.swift
@@ -1,67 +1,69 @@
 import Foundation
 
 struct Genre {
-    let id: String
-    let name: String
-    let category: GenreCategory
-    let googleMapType: String
-    
-    init(id: String = UUID().uuidString, name: String, category: GenreCategory, googleMapType: String) {
-        self.id = id
-        self.name = name
-        self.category = category
-        self.googleMapType = googleMapType
-    }
+	let id: String
+	let name: String
+	let category: GenreCategory
+	let googleMapType: String
+	let hint: String?
+	
+	init(id: String = UUID().uuidString, name: String, category: GenreCategory, googleMapType: String, hint: String? = nil) {
+		self.id = id
+		self.name = name
+		self.category = category
+		self.googleMapType = googleMapType
+		self.hint = hint
+	}
 }
 
 enum GenreCategory: String, CaseIterable {
-    case restaurant = "restaurant"
-    case other = "other"
-    
-    var displayName: String {
-        switch self {
-        case .restaurant: return "グルメ"
-        case .other: return "その他"
-        }
-    }
-    
-    var emoji: String {
-        switch self {
-        case .restaurant: return "🍽️"
-        case .other: return "🏛️"
-        }
-    }
-    
-    // 30% : 70% の比率でカテゴリを決定
-    static func getRandomCategory() -> GenreCategory {
-        return Int.random(in: 1...10) <= 3 ? .restaurant : .other
-    }
-    
-    // 指定された数でカテゴリを分配
-    static func distributeCategories(totalCount: Int) -> [GenreCategory] {
-        let restaurantCount = max(1, Int(Double(totalCount) * 0.3))
-        let otherCount = totalCount - restaurantCount
-        
-        var categories: [GenreCategory] = []
-        categories.append(contentsOf: Array(repeating: .restaurant, count: restaurantCount))
-        categories.append(contentsOf: Array(repeating: .other, count: otherCount))
-        
-        return categories.shuffled()
-    }
+	case restaurant = "restaurant"
+	case other = "other"
+	
+	var displayName: String {
+		switch self {
+		case .restaurant: return "グルメ"
+		case .other: return "その他"
+		}
+	}
+	
+	var emoji: String {
+		switch self {
+		case .restaurant: return "🍽️"
+		case .other: return "🏛️"
+		}
+	}
+	
+	// 30% : 70% の比率でカテゴリを決定
+	static func getRandomCategory() -> GenreCategory {
+		return Int.random(in: 1...10) <= 3 ? .restaurant : .other
+	}
+	
+	// 指定された数でカテゴリを分配
+	static func distributeCategories(totalCount: Int) -> [GenreCategory] {
+		let restaurantCount = max(1, Int(Double(totalCount) * 0.3))
+		let otherCount = totalCount - restaurantCount
+		
+		var categories: [GenreCategory] = []
+		categories.append(contentsOf: Array(repeating: .restaurant, count: restaurantCount))
+		categories.append(contentsOf: Array(repeating: .other, count: otherCount))
+		
+		return categories.shuffled()
+	}
 }
 
 // MARK: - Equatable
 extension Genre: Equatable {
-    static func == (lhs: Genre, rhs: Genre) -> Bool {
-        return lhs.id == rhs.id
-    }
+	static func == (lhs: Genre, rhs: Genre) -> Bool {
+		return lhs.id == rhs.id
+	}
 }
 
 // MARK: - Hashable
 extension Genre: Hashable {
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(id)
-    }
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(id)
+	}
 }
 
 // MARK: - Codable
@@ -70,21 +72,21 @@ extension GenreCategory: Codable {}
 
 // MARK: - Common Genres
 extension Genre {
-    static let commonRestaurantGenres = [
-        Genre(name: "カフェ", category: .restaurant, googleMapType: "cafe"),
-        Genre(name: "レストラン", category: .restaurant, googleMapType: "restaurant"),
-        Genre(name: "ファストフード", category: .restaurant, googleMapType: "meal_takeaway"),
-        Genre(name: "バー", category: .restaurant, googleMapType: "bar"),
-        Genre(name: "ベーカリー", category: .restaurant, googleMapType: "bakery")
-    ]
-    
-    static let commonOtherGenres = [
-        Genre(name: "公園", category: .other, googleMapType: "park"),
-        Genre(name: "美術館", category: .other, googleMapType: "museum"),
-        Genre(name: "図書館", category: .other, googleMapType: "library"),
-        Genre(name: "書店", category: .other, googleMapType: "book_store"),
-        Genre(name: "ショッピングモール", category: .other, googleMapType: "shopping_mall"),
-        Genre(name: "神社・寺院", category: .other, googleMapType: "place_of_worship"),
-        Genre(name: "映画館", category: .other, googleMapType: "movie_theater")
-    ]
+	static let commonRestaurantGenres = [
+		Genre(name: "カフェ", category: .restaurant, googleMapType: "cafe"),
+		Genre(name: "レストラン", category: .restaurant, googleMapType: "restaurant"),
+		Genre(name: "ファストフード", category: .restaurant, googleMapType: "meal_takeaway"),
+		Genre(name: "バー", category: .restaurant, googleMapType: "bar"),
+		Genre(name: "ベーカリー", category: .restaurant, googleMapType: "bakery")
+	]
+	
+	static let commonOtherGenres = [
+		Genre(name: "公園", category: .other, googleMapType: "park"),
+		Genre(name: "美術館", category: .other, googleMapType: "museum"),
+		Genre(name: "図書館", category: .other, googleMapType: "library"),
+		Genre(name: "書店", category: .other, googleMapType: "book_store"),
+		Genre(name: "ショッピングモール", category: .other, googleMapType: "shopping_mall"),
+		Genre(name: "神社・寺院", category: .other, googleMapType: "place_of_worship"),
+		Genre(name: "映画館", category: .other, googleMapType: "movie_theater")
+	]
 }

--- a/DontGoHomeStraight/Domain/Repositories/AIRecommendationRepository.swift
+++ b/DontGoHomeStraight/Domain/Repositories/AIRecommendationRepository.swift
@@ -40,7 +40,7 @@ struct PlaceHintInput {
 	let spotName: String
 	let category: GenreCategory
 	let isIndoor: Bool
-	let vibe: Mood.VibeType
+	let vibe: VibeType
 	let transportMode: TransportMode
 }
 

--- a/DontGoHomeStraight/Domain/Repositories/AIRecommendationRepository.swift
+++ b/DontGoHomeStraight/Domain/Repositories/AIRecommendationRepository.swift
@@ -2,83 +2,92 @@ import Foundation
 import CoreLocation
 
 protocol AIRecommendationRepository {
-    func getRecommendations(request: AIRecommendationRequest) async throws -> [LLMCandidate]
-    func validateRecommendation(spotName: String, location: CLLocationCoordinate2D) async throws -> Bool
+	func getRecommendations(request: AIRecommendationRequest) async throws -> [LLMCandidate]
+	func validateRecommendation(spotName: String, location: CLLocationCoordinate2D) async throws -> Bool
+	func generateHint(for place: PlaceHintInput) async throws -> String
 }
 
 struct AIRecommendationRequest {
-    let currentLocation: CLLocationCoordinate2D
-    let destination: CLLocationCoordinate2D
-    let currentTime: Date
-    let mood: Mood
-    let transportMode: TransportMode
-    let excludedPlaceIds: [String]
-    
-    func toPrompt() -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy年MM月dd日 HH:mm"
-        
-        return """
-        現在地: \(currentLocation.latitude), \(currentLocation.longitude)
-        目的地: \(destination.latitude), \(destination.longitude)
-        現在時刻: \(formatter.string(from: currentTime))
-        気分: \(mood.description)
-        移動手段: \(transportMode.displayName)
-        除外スポット(place_id): \(excludedPlaceIds.joined(separator: ", "))
-        
-        上記の条件で候補スポットを10件提案してください。各候補は以下のフィールドを含めてください。
-        - name: Googleで実在する具体的名称
-        - category: "restaurant" または "other"
-        
-        回答は厳密にJSON配列で返してください（説明文は不要）。
-        """
-    }
+	let currentLocation: CLLocationCoordinate2D
+	let destination: CLLocationCoordinate2D
+	let currentTime: Date
+	let mood: Mood
+	let transportMode: TransportMode
+	let excludedPlaceIds: [String]
+	
+	func toPrompt() -> String {
+		let formatter = DateFormatter()
+		formatter.dateFormat = "yyyy年MM月dd日 HH:mm"
+		
+		return """
+		現在地: \(currentLocation.latitude), \(currentLocation.longitude)
+		目的地: \(destination.latitude), \(destination.longitude)
+		現在時刻: \(formatter.string(from: currentTime))
+		気分: \(mood.description)
+		移動手段: \(transportMode.displayName)
+		除外スポット(place_id): \(excludedPlaceIds.joined(separator: ", "))
+		
+		上記の条件で候補スポットを10件提案してください。各候補は以下のフィールドを含めてください。
+		- name: Googleで実在する具体的名称
+		- category: "restaurant" または "other"
+		
+		回答は厳密にJSON配列で返してください（説明文は不要）。
+		"""
+	}
+}
+
+struct PlaceHintInput {
+	let spotName: String
+	let category: GenreCategory
+	let isIndoor: Bool
+	let vibe: Mood.VibeType
+	let transportMode: TransportMode
 }
 
 struct LLMCandidate: Codable, Equatable {
-    let name: String
-    let category: GenreCategory
+	let name: String
+	let category: GenreCategory
 }
 
 // Codable bridge for GenreCategory in LLMCandidate
 extension LLMCandidate {
-    private enum CodingKeys: String, CodingKey { case name, category }
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.name = try container.decode(String.self, forKey: .name)
-        let categoryRaw = try container.decode(String.self, forKey: .category)
-        self.category = GenreCategory(rawValue: categoryRaw) ?? .other
-    }
-    func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(name, forKey: .name)
-        try container.encode(category.rawValue, forKey: .category)
-    }
+	private enum CodingKeys: String, CodingKey { case name, category }
+	init(from decoder: Decoder) throws {
+		let container = try decoder.container(keyedBy: CodingKeys.self)
+		self.name = try container.decode(String.self, forKey: .name)
+		let categoryRaw = try container.decode(String.self, forKey: .category)
+		self.category = GenreCategory(rawValue: categoryRaw) ?? .other
+	}
+	func encode(to encoder: Encoder) throws {
+		var container = encoder.container(keyedBy: CodingKeys.self)
+		try container.encode(name, forKey: .name)
+		try container.encode(category.rawValue, forKey: .category)
+	}
 }
 
 
 enum AIRecommendationError: LocalizedError {
-    case noValidPlaces
-    case aiServiceUnavailable
-    case invalidResponse
-    case apiKeyInvalid
-    case quotaExceeded
-    case networkError
-    
-    var errorDescription: String? {
-        switch self {
-        case .noValidPlaces:
-            return "候補地がありません。今日はまっすぐ帰りましょう🎵"
-        case .aiServiceUnavailable:
-            return "AI推薦サービスが一時的に利用できません"
-        case .invalidResponse:
-            return "AIからの応答が無効です"
-        case .apiKeyInvalid:
-            return "OpenAI APIキーが無効です"
-        case .quotaExceeded:
-            return "AI API利用制限に達しました"
-        case .networkError:
-            return "ネットワークエラーが発生しました"
-        }
-    }
+	case noValidPlaces
+	case aiServiceUnavailable
+	case invalidResponse
+	case apiKeyInvalid
+	case quotaExceeded
+	case networkError
+	
+	var errorDescription: String? {
+		switch self {
+		case .noValidPlaces:
+			return "候補地がありません。今日はまっすぐ帰りましょう🎵"
+		case .aiServiceUnavailable:
+			return "AI推薦サービスが一時的に利用できません"
+		case .invalidResponse:
+			return "AIからの応答が無効です"
+		case .apiKeyInvalid:
+			return "OpenAI APIキーが無効です"
+		case .quotaExceeded:
+			return "AI API利用制限に達しました"
+		case .networkError:
+			return "ネットワークエラーが発生しました"
+		}
+	}
 }

--- a/DontGoHomeStraight/Infrastructure/Repositories/AIRecommendationRepositoryImpl.swift
+++ b/DontGoHomeStraight/Infrastructure/Repositories/AIRecommendationRepositoryImpl.swift
@@ -46,6 +46,10 @@ class AIRecommendationRepositoryImpl: AIRecommendationRepository {
         
         return hasValidCharacters
     }
+    
+    func generateHint(for place: PlaceHintInput) async throws -> String {
+        return try await openAIClient.generateHint(for: place)
+    }
 }
 
 

--- a/DontGoHomeStraight/Presentation/ViewModels/AppViewModel.swift
+++ b/DontGoHomeStraight/Presentation/ViewModels/AppViewModel.swift
@@ -434,6 +434,16 @@ class MockAIRecommendationRepository: AIRecommendationRepository {
     func validateRecommendation(spotName: String, location: CLLocationCoordinate2D) async throws -> Bool {
         return true
     }
+    
+    func generateHint(for place: PlaceHintInput) async throws -> String {
+        // モック実装：適当なヒントを返す
+        switch place.category {
+        case .restaurant:
+            return "美味しいコーヒーと落ち着いた雰囲気"
+        case .other:
+            return "緑豊かな都会のオアシス"
+        }
+    }
 }
 
 class MockPlaceRepository: PlaceRepository {

--- a/DontGoHomeStraight/Presentation/Views/GenreSelectionView.swift
+++ b/DontGoHomeStraight/Presentation/Views/GenreSelectionView.swift
@@ -215,6 +215,13 @@ struct GenreCard: View {
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                     
+                    if let hint = genre.hint, hint.isEmpty == false {
+                        Text("ヒント：\(hint)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
+                    
                     Text(genre.description)
                         .font(.caption)
                         .foregroundColor(.secondary)
@@ -364,6 +371,13 @@ struct EnhancedGenreCard: View {
                     Text(genre.category.displayName)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
+                    
+                    if let hint = genre.hint, hint.isEmpty == false {
+                        Text("ヒント：\(hint)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
                     
                     Text(genre.description)
                         .font(.caption)


### PR DESCRIPTION
## 概要

Issue #14 に基づいてUIを刷新し、ヒント生成機能の基盤を整備しました。

## 実装内容

### ✅ 実装済み機能
- **ヒント生成機能の基盤整備**
  - AIRecommendationRepositoryにgenerateHintメソッドを追加
  - OpenAIAPIClientにgenerateHintメソッドを実装（30文字程度のヒント生成）
  - Genreエンティティにhintプロパティを追加
  - GenreSelectionViewでヒントを表示する準備
  
- **モダンなUIデザインシステムの適用**
  - BrandButton、LogoViewなどのコンポーネント
  - スッキリとしたカラーパレット

### 🐛 修正内容
- MockAIRecommendationRepositoryにgenerateHintメソッドを追加（ビルドエラー修正）
- Mood.VibeTypeをVibeTypeに修正（型エラー修正）

### ⚠️ 未実装機能
- **実際のヒント生成処理**（PlaceRecommendationUseCaseでの統合）
- スポット名のマスク表示（＊＊＊）機能
- タブ形式のUI（現在は画面遷移UIのまま）

## 関連Issue
- Partially addresses #14

## テスト
- ビルドが成功することを確認 ✅

## 次のステップ
PlaceRecommendationUseCaseでヒント生成APIを呼び出し、実際にヒントを生成する処理を実装する必要があります。

## コミット履歴
- feat(issue #14): refresh UI and add OpenAI hint generation
- fix: MockAIRecommendationRepositoryにgenerateHintメソッドを追加、Mood.VibeTypeをVibeTypeに修正